### PR TITLE
Add offline zones tracker web app

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,49 @@
-# Codex
-A playground repo for building Khal's Zones of Regulation web app.
+# Khal Zones Tracker
+
+A kid-friendly, offline-ready web app to help Khal identify and log his Zone of Regulation right from an iPad. The entire app is client-side and saves data in the browser using `localStorage`.
+
+## Getting started
+
+1. Download this project.
+2. Double-click `index.html` (or open it in any modern desktop/mobile browser). No build step or server is required.
+
+## Using the app
+
+### Log a zone
+
+* Tap one of the large zone cards to instantly log how you are feeling.
+* An optional note pop-up appears—type a short note and press **Save note**, or choose **Skip** to dismiss it.
+* Notes can be up to 120 characters and attach to the entry you just logged.
+
+### Teacher view
+
+* Tap **Teacher View** to reveal the history table, filters, and data tools.
+* Filters allow you to narrow the history by date range (today, this week, all time, or a custom range) and by zone color.
+* Use the checkboxes in the table to select entries for deletion.
+
+### Export & delete
+
+* **Export CSV** downloads the currently filtered log as `khal-zones-YYYY-MM-DD.csv` with columns `timestamp,localDateTime,zone,note`.
+* **Delete selected** removes the checked entries from the table and storage.
+* **Clear all data** empties the entire log after confirming. This cannot be undone.
+
+## Data storage
+
+Entries are saved as a JSON array under the `localStorage` key `khalZonesLog`. Each entry looks like:
+
+```json
+{
+  "timestamp": "2025-09-26T14:32:10.123Z",
+  "zone": "green",
+  "note": "Recess went well"
+}
+```
+
+Because data lives in the browser, refreshing or reopening the page keeps the log intact. Clearing browser storage or opening the page in a different browser/device starts with a fresh log.
+
+## File overview
+
+* `index.html` – Single-page layout with zone cards, today summary, and teacher tools.
+* `styles.css` – Touch-friendly styling, color tokens, dark-mode support, and responsive layout.
+* `app.js` – Handles storage, logging, filtering, exporting, and accessibility helpers.
+* `README.md` – This file.

--- a/app.js
+++ b/app.js
@@ -1,0 +1,389 @@
+(function () {
+  const STORAGE_KEY = 'khalZonesLog';
+  const zoneDetails = {
+    blue: { label: 'Blue', description: 'Sad / Tired', emoji: '🟦' },
+    green: { label: 'Green', description: 'Ready to Learn', emoji: '🟩' },
+    yellow: { label: 'Yellow', description: 'Worried / Excited', emoji: '🟨' },
+    red: { label: 'Red', description: 'Angry / Out of Control', emoji: '🟥' }
+  };
+
+  const zoneButtons = document.querySelectorAll('.zone-card');
+  const todayCountsEl = document.getElementById('todayCounts');
+  const timelineEl = document.getElementById('timeline');
+  const historyBody = document.getElementById('historyBody');
+  const teacherToggle = document.getElementById('teacherToggle');
+  const teacherPanel = document.getElementById('teacherPanel');
+  const dateFilter = document.getElementById('dateFilter');
+  const customDateInputs = document.getElementById('customDateInputs');
+  const startDateInput = document.getElementById('startDate');
+  const endDateInput = document.getElementById('endDate');
+  const zoneFilterInputs = Array.from(document.querySelectorAll('input[name="zoneFilter"]'));
+  const exportButton = document.getElementById('exportCsv');
+  const deleteSelectedButton = document.getElementById('deleteSelected');
+  const clearAllButton = document.getElementById('clearAll');
+  const noteModal = document.getElementById('noteModal');
+  const noteForm = document.getElementById('noteForm');
+  const noteTextarea = document.getElementById('noteText');
+  const skipNoteButton = document.getElementById('skipNote');
+  const liveRegion = document.getElementById('liveRegion');
+
+  let entries = loadEntries();
+  let pendingTimestamp = null;
+
+  zoneButtons.forEach((button) => {
+    button.addEventListener('click', () => {
+      const zone = button.dataset.zone;
+      const entry = addEntry(zone, '');
+      pendingTimestamp = entry.timestamp;
+      announce(`Logged ${zoneDetails[zone].label} at ${formatLocalTime(entry.timestamp)}.`);
+      openModal();
+    });
+  });
+
+  teacherToggle.addEventListener('click', () => {
+    const isActive = document.body.classList.toggle('teacher-mode');
+    teacherToggle.setAttribute('aria-pressed', String(isActive));
+    teacherToggle.textContent = isActive ? '🙈 Hide Teacher View' : '👩‍🏫 Teacher View';
+    if (isActive) {
+      teacherToggle.setAttribute('aria-expanded', 'true');
+      if (teacherPanel && typeof teacherPanel.focus === 'function') {
+        teacherPanel.focus();
+      }
+    } else {
+      teacherToggle.setAttribute('aria-expanded', 'false');
+    }
+  });
+
+  dateFilter.addEventListener('change', () => {
+    const isCustom = dateFilter.value === 'custom';
+    customDateInputs.style.display = isCustom ? 'flex' : 'none';
+    renderHistory();
+  });
+
+  [startDateInput, endDateInput].forEach((input) => {
+    input.addEventListener('change', renderHistory);
+  });
+
+  zoneFilterInputs.forEach((input) => {
+    input.addEventListener('change', renderHistory);
+  });
+
+  exportButton.addEventListener('click', () => {
+    const filtered = getFilteredEntries();
+    if (!filtered.length) {
+      alert('No entries to export for the selected filters.');
+      return;
+    }
+    const csv = buildCsv(filtered);
+    const today = new Date();
+    const filename = `khal-zones-${today.toISOString().slice(0, 10)}.csv`;
+    const blob = new Blob([csv], { type: 'text/csv;charset=utf-8;' });
+    const url = URL.createObjectURL(blob);
+    const link = document.createElement('a');
+    link.href = url;
+    link.download = filename;
+    document.body.appendChild(link);
+    link.click();
+    document.body.removeChild(link);
+    URL.revokeObjectURL(url);
+  });
+
+  deleteSelectedButton.addEventListener('click', () => {
+    const checkboxes = historyBody.querySelectorAll('input[type="checkbox"][data-timestamp]:checked');
+    const timestamps = Array.from(checkboxes).map((cb) => cb.dataset.timestamp);
+    if (!timestamps.length) {
+      alert('Select at least one entry to delete.');
+      return;
+    }
+    if (!confirm(`Delete ${timestamps.length} selected entr${timestamps.length === 1 ? 'y' : 'ies'}?`)) {
+      return;
+    }
+    deleteEntries(timestamps);
+  });
+
+  clearAllButton.addEventListener('click', () => {
+    if (!entries.length) {
+      alert('Nothing to clear!');
+      return;
+    }
+    if (confirm('Clear all saved data? This cannot be undone.')) {
+      clearAll();
+    }
+  });
+
+  noteForm.addEventListener('submit', (event) => {
+    event.preventDefault();
+    if (!pendingTimestamp) {
+      closeModal();
+      return;
+    }
+    const note = noteTextarea.value.trim();
+    if (note) {
+      updateEntryNote(pendingTimestamp, note);
+    }
+    closeModal();
+  });
+
+  skipNoteButton.addEventListener('click', () => {
+    closeModal();
+  });
+
+  document.addEventListener('keydown', (event) => {
+    if (event.key === 'Escape' && !noteModal.classList.contains('hidden')) {
+      closeModal();
+    }
+  });
+
+  noteModal.addEventListener('click', (event) => {
+    if (event.target === noteModal) {
+      closeModal();
+    }
+  });
+
+  renderAll();
+
+  function loadEntries() {
+    try {
+      const raw = localStorage.getItem(STORAGE_KEY);
+      if (!raw) return [];
+      const parsed = JSON.parse(raw);
+      if (!Array.isArray(parsed)) return [];
+      return parsed.filter((entry) => entry && entry.timestamp && entry.zone);
+    } catch (error) {
+      console.warn('Could not load entries:', error);
+      return [];
+    }
+  }
+
+  function saveEntries() {
+    try {
+      localStorage.setItem(STORAGE_KEY, JSON.stringify(entries));
+    } catch (error) {
+      console.warn('Could not save entries:', error);
+    }
+  }
+
+  function addEntry(zone, note = '') {
+    const timestamp = new Date().toISOString();
+    const entry = { timestamp, zone, note };
+    entries.push(entry);
+    saveEntries();
+    renderAll();
+    return entry;
+  }
+
+  function updateEntryNote(timestamp, note) {
+    const entry = entries.find((item) => item.timestamp === timestamp);
+    if (entry) {
+      entry.note = note;
+      saveEntries();
+      renderAll();
+    }
+  }
+
+  function deleteEntries(timestamps) {
+    entries = entries.filter((entry) => !timestamps.includes(entry.timestamp));
+    saveEntries();
+    renderAll();
+  }
+
+  function clearAll() {
+    entries = [];
+    saveEntries();
+    renderAll();
+  }
+
+  function renderAll() {
+    renderTodaySummary();
+    renderHistory();
+  }
+
+  function renderTodaySummary() {
+    const todayEntries = entries.filter((entry) => isSameDay(new Date(entry.timestamp), new Date()));
+    const counts = {
+      blue: 0,
+      green: 0,
+      yellow: 0,
+      red: 0
+    };
+    todayEntries.forEach((entry) => {
+      if (counts[entry.zone] !== undefined) {
+        counts[entry.zone] += 1;
+      }
+    });
+
+    todayCountsEl.innerHTML = '';
+    Object.keys(counts).forEach((zone) => {
+      const chip = document.createElement('div');
+      chip.className = 'count-chip';
+      chip.dataset.zone = zone;
+      chip.setAttribute('role', 'listitem');
+      chip.innerHTML = `<span>${zoneDetails[zone].emoji}</span><span>${zoneDetails[zone].label}: ${counts[zone]}</span>`;
+      todayCountsEl.appendChild(chip);
+    });
+
+    timelineEl.innerHTML = '';
+    todayEntries
+      .sort((a, b) => new Date(a.timestamp) - new Date(b.timestamp))
+      .forEach((entry) => {
+        const chip = document.createElement('div');
+        chip.className = 'timeline-chip';
+        chip.dataset.zone = entry.zone;
+        chip.setAttribute('role', 'listitem');
+        chip.innerHTML = `<span>${zoneDetails[entry.zone].emoji}</span><span>${formatLocalTime(entry.timestamp)}</span>`;
+        timelineEl.appendChild(chip);
+      });
+  }
+
+  function renderHistory() {
+    const filtered = getFilteredEntries();
+    historyBody.innerHTML = '';
+
+    if (!filtered.length) {
+      const row = document.createElement('tr');
+      const cell = document.createElement('td');
+      cell.colSpan = 4;
+      cell.textContent = 'No entries yet.';
+      row.appendChild(cell);
+      historyBody.appendChild(row);
+      return;
+    }
+
+    filtered.forEach((entry) => {
+      const row = document.createElement('tr');
+      const selectCell = document.createElement('td');
+      selectCell.className = 'select-col';
+      const checkbox = document.createElement('input');
+      checkbox.type = 'checkbox';
+      checkbox.dataset.timestamp = entry.timestamp;
+      checkbox.setAttribute('aria-label', `Select entry from ${formatLocalDateTime(entry.timestamp)}`);
+      selectCell.appendChild(checkbox);
+
+      const dateCell = document.createElement('td');
+      dateCell.textContent = formatLocalDateTime(entry.timestamp);
+
+      const zoneCell = document.createElement('td');
+      const chip = document.createElement('span');
+      chip.className = 'zone-chip';
+      chip.dataset.zone = entry.zone;
+      chip.innerHTML = `<span aria-hidden="true">${zoneDetails[entry.zone].emoji}</span><span>${zoneDetails[entry.zone].label}</span>`;
+      zoneCell.appendChild(chip);
+
+      const noteCell = document.createElement('td');
+      noteCell.textContent = entry.note || '—';
+
+      row.appendChild(selectCell);
+      row.appendChild(dateCell);
+      row.appendChild(zoneCell);
+      row.appendChild(noteCell);
+      historyBody.appendChild(row);
+    });
+  }
+
+  function getFilteredEntries() {
+    let filtered = [...entries];
+    filtered.sort((a, b) => new Date(b.timestamp) - new Date(a.timestamp));
+
+    const selectedZones = zoneFilterInputs.filter((input) => input.checked).map((input) => input.value);
+    if (selectedZones.length && selectedZones.length < zoneFilterInputs.length) {
+      filtered = filtered.filter((entry) => selectedZones.includes(entry.zone));
+    }
+
+    const now = new Date();
+    if (dateFilter.value === 'today') {
+      filtered = filtered.filter((entry) => isSameDay(new Date(entry.timestamp), now));
+    } else if (dateFilter.value === 'week') {
+      filtered = filtered.filter((entry) => isSameWeek(new Date(entry.timestamp), now));
+    } else if (dateFilter.value === 'custom') {
+      const start = startDateInput.value ? new Date(startDateInput.value) : null;
+      const end = endDateInput.value ? endOfDay(new Date(endDateInput.value)) : null;
+      filtered = filtered.filter((entry) => {
+        const date = new Date(entry.timestamp);
+        if (start && date < start) return false;
+        if (end && date > end) return false;
+        return true;
+      });
+    }
+
+    return filtered;
+  }
+
+  function buildCsv(data) {
+    const header = ['timestamp', 'localDateTime', 'zone', 'note'];
+    const rows = data.map((entry) => [
+      entry.timestamp,
+      escapeCsv(formatLocalDateTime(entry.timestamp)),
+      entry.zone,
+      escapeCsv(entry.note || '')
+    ]);
+    return [header.join(','), ...rows.map((row) => row.join(','))].join('\n');
+  }
+
+  function escapeCsv(value) {
+    if (value.includes('"') || value.includes(',') || value.includes('\n')) {
+      return '"' + value.replace(/"/g, '""') + '"';
+    }
+    return value;
+  }
+
+  function formatLocalTime(timestamp) {
+    const date = new Date(timestamp);
+    return date.toLocaleTimeString([], { hour: 'numeric', minute: '2-digit' });
+  }
+
+  function formatLocalDateTime(timestamp) {
+    const date = new Date(timestamp);
+    return date.toLocaleString([], {
+      year: 'numeric',
+      month: 'short',
+      day: 'numeric',
+      hour: 'numeric',
+      minute: '2-digit'
+    });
+  }
+
+  function isSameDay(a, b) {
+    return (
+      a.getFullYear() === b.getFullYear() &&
+      a.getMonth() === b.getMonth() &&
+      a.getDate() === b.getDate()
+    );
+  }
+
+  function isSameWeek(date, reference) {
+    const startOfWeek = new Date(reference);
+    startOfWeek.setHours(0, 0, 0, 0);
+    const day = startOfWeek.getDay();
+    startOfWeek.setDate(startOfWeek.getDate() - day);
+
+    const endOfWeek = new Date(startOfWeek);
+    endOfWeek.setDate(endOfWeek.getDate() + 7);
+
+    return date >= startOfWeek && date < endOfWeek;
+  }
+
+  function endOfDay(date) {
+    const end = new Date(date);
+    end.setHours(23, 59, 59, 999);
+    return end;
+  }
+
+  function openModal() {
+    noteModal.classList.remove('hidden');
+    noteTextarea.value = '';
+    noteTextarea.focus();
+  }
+
+  function closeModal() {
+    noteModal.classList.add('hidden');
+    noteTextarea.value = '';
+    pendingTimestamp = null;
+  }
+
+  function announce(message) {
+    liveRegion.textContent = '';
+    setTimeout(() => {
+      liveRegion.textContent = message;
+    }, 50);
+  }
+})();

--- a/index.html
+++ b/index.html
@@ -1,0 +1,131 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Khal's Zones</title>
+  <link rel="stylesheet" href="styles.css" />
+</head>
+<body>
+  <header class="app-header">
+    <div class="title-block">
+      <h1>What zone am I in?</h1>
+      <p class="subtitle">Tap how you feel. Add a note if you want.</p>
+    </div>
+    <button id="teacherToggle" class="teacher-toggle" aria-pressed="false" aria-expanded="false" aria-controls="teacherPanel">
+      👩‍🏫 Teacher View
+    </button>
+  </header>
+
+  <main>
+    <section class="zones" aria-labelledby="zonePickerHeading">
+      <h2 id="zonePickerHeading" class="sr-only">Choose a zone</h2>
+      <div class="zone-grid">
+        <button class="zone-card" data-zone="blue" aria-label="Blue zone, sad or tired">
+          <span class="emoji" aria-hidden="true">🟦</span>
+          <span class="label">Blue Zone</span>
+          <span class="kid-words">Sad · Tired · Slow</span>
+        </button>
+        <button class="zone-card" data-zone="green" aria-label="Green zone, ready to learn">
+          <span class="emoji" aria-hidden="true">🟩</span>
+          <span class="label">Green Zone</span>
+          <span class="kid-words">Happy · Ready · Calm</span>
+        </button>
+        <button class="zone-card" data-zone="yellow" aria-label="Yellow zone, worried or excited">
+          <span class="emoji" aria-hidden="true">🟨</span>
+          <span class="label">Yellow Zone</span>
+          <span class="kid-words">Wiggly · Worried · Silly</span>
+        </button>
+        <button class="zone-card" data-zone="red" aria-label="Red zone, angry or out of control">
+          <span class="emoji" aria-hidden="true">🟥</span>
+          <span class="label">Red Zone</span>
+          <span class="kid-words">Mad · Yelling · Out of Control</span>
+        </button>
+      </div>
+    </section>
+
+    <section class="summary" aria-labelledby="summaryHeading">
+      <h2 id="summaryHeading">Today at a glance</h2>
+      <div id="todayCounts" class="today-counts" role="list" aria-live="polite"></div>
+      <div id="timeline" class="timeline" aria-label="Today entries timeline" role="list"></div>
+    </section>
+
+    <section id="teacherPanel" class="teacher-panel teacher-only" aria-labelledby="teacherHeading" tabindex="-1">
+      <div class="teacher-panel-header">
+        <h2 id="teacherHeading">History &amp; Log</h2>
+      </div>
+
+      <form id="filters" class="filters" aria-label="Filter log entries">
+        <fieldset>
+          <legend>Date range</legend>
+          <label>
+            <span class="sr-only">Date range</span>
+            <select id="dateFilter" name="dateFilter">
+              <option value="today">Today</option>
+              <option value="week">This week</option>
+              <option value="all" selected>All time</option>
+              <option value="custom">Custom range</option>
+            </select>
+          </label>
+          <div class="custom-date" id="customDateInputs">
+            <label>
+              Start
+              <input type="date" id="startDate" name="startDate" />
+            </label>
+            <label>
+              End
+              <input type="date" id="endDate" name="endDate" />
+            </label>
+          </div>
+        </fieldset>
+        <fieldset>
+          <legend>Zones</legend>
+          <label><input type="checkbox" name="zoneFilter" value="blue" checked /> Blue</label>
+          <label><input type="checkbox" name="zoneFilter" value="green" checked /> Green</label>
+          <label><input type="checkbox" name="zoneFilter" value="yellow" checked /> Yellow</label>
+          <label><input type="checkbox" name="zoneFilter" value="red" checked /> Red</label>
+        </fieldset>
+      </form>
+
+      <div class="table-actions">
+        <button id="exportCsv" type="button">⬇️ Export CSV</button>
+        <button id="deleteSelected" type="button">🗑️ Delete selected</button>
+        <button id="clearAll" type="button">🚨 Clear all data</button>
+      </div>
+
+      <div class="table-wrapper">
+        <table aria-describedby="teacherHeading">
+          <thead>
+            <tr>
+              <th scope="col" class="select-col"><span class="sr-only">Select entry</span></th>
+              <th scope="col">Date &amp; Time</th>
+              <th scope="col">Zone</th>
+              <th scope="col">Note</th>
+            </tr>
+          </thead>
+          <tbody id="historyBody"></tbody>
+        </table>
+      </div>
+    </section>
+  </main>
+
+  <div id="noteModal" class="modal hidden" role="dialog" aria-modal="true" aria-labelledby="noteTitle">
+    <div class="modal-content">
+      <h2 id="noteTitle">Add a note?</h2>
+      <p class="modal-subtitle">Tell us what happened (optional).</p>
+      <form id="noteForm">
+        <label for="noteText" class="sr-only">Note</label>
+        <textarea id="noteText" name="note" rows="3" maxlength="120" placeholder="What happened? (optional)"></textarea>
+        <div class="modal-actions">
+          <button type="submit" class="primary">Save note</button>
+          <button type="button" id="skipNote" class="secondary">Skip</button>
+        </div>
+      </form>
+    </div>
+  </div>
+
+  <div id="liveRegion" class="sr-only" aria-live="polite"></div>
+
+  <script src="app.js"></script>
+</body>
+</html>

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,452 @@
+:root {
+  color-scheme: light dark;
+  --blue: #6cb6ff;
+  --green: #34c759;
+  --yellow: #ffd60a;
+  --red: #ff453a;
+  --surface: rgba(255, 255, 255, 0.82);
+  --surface-dark: rgba(27, 27, 31, 0.82);
+  --text: #111;
+  --text-dark: #f5f5f5;
+  --accent: #2563eb;
+  --shadow: 0 10px 30px rgba(0, 0, 0, 0.08);
+  font-family: "SF Pro Rounded", "Segoe UI", "Helvetica Neue", system-ui, sans-serif;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  background: linear-gradient(160deg, rgba(108, 182, 255, 0.2), rgba(52, 199, 89, 0.15));
+  color: var(--text);
+  font-family: inherit;
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+  padding: clamp(1.5rem, 4vw, 3rem);
+}
+
+@media (prefers-color-scheme: dark) {
+  body {
+    background: linear-gradient(160deg, rgba(108, 182, 255, 0.15), rgba(52, 199, 89, 0.1));
+    color: var(--text-dark);
+  }
+}
+
+main {
+  display: flex;
+  flex-direction: column;
+  gap: clamp(1.5rem, 3vw, 2.5rem);
+}
+
+.app-header {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.title-block h1 {
+  margin: 0;
+  font-size: clamp(2.4rem, 5vw, 3.5rem);
+  letter-spacing: -0.03em;
+}
+
+.subtitle {
+  margin: 0.25rem 0 0;
+  font-size: clamp(1rem, 2.5vw, 1.3rem);
+  opacity: 0.85;
+}
+
+.teacher-toggle {
+  background: var(--surface);
+  border: 2px solid rgba(0, 0, 0, 0.12);
+  border-radius: 999px;
+  padding: 0.75rem 1.25rem;
+  font-size: 1.1rem;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  cursor: pointer;
+  box-shadow: var(--shadow);
+  transition: transform 0.15s ease, box-shadow 0.2s ease;
+}
+
+.teacher-toggle[aria-pressed="true"] {
+  background: var(--accent);
+  color: white;
+  border-color: transparent;
+}
+
+.teacher-toggle:focus-visible,
+.zone-card:focus-visible,
+.table-actions button:focus-visible,
+.modal-actions button:focus-visible {
+  outline: 3px solid rgba(37, 99, 235, 0.7);
+  outline-offset: 2px;
+}
+
+.zones {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.zone-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+  gap: clamp(1rem, 2vw, 1.5rem);
+}
+
+.zone-card {
+  border: none;
+  border-radius: 24px;
+  padding: 1.75rem 1.25rem;
+  font-size: 1.2rem;
+  text-align: center;
+  background: var(--surface);
+  color: inherit;
+  cursor: pointer;
+  display: flex;
+  flex-direction: column;
+  gap: 0.6rem;
+  align-items: center;
+  justify-content: center;
+  min-height: 140px;
+  box-shadow: var(--shadow);
+  transition: transform 0.15s ease, box-shadow 0.2s ease;
+  border: 4px solid transparent;
+}
+
+.zone-card:active {
+  transform: scale(0.97);
+}
+
+.zone-card[data-zone="blue"] {
+  border-color: var(--blue);
+}
+
+.zone-card[data-zone="green"] {
+  border-color: var(--green);
+}
+
+.zone-card[data-zone="yellow"] {
+  border-color: var(--yellow);
+}
+
+.zone-card[data-zone="red"] {
+  border-color: var(--red);
+}
+
+.zone-card .emoji {
+  font-size: 2.5rem;
+}
+
+.zone-card .label {
+  font-weight: 700;
+}
+
+.zone-card .kid-words {
+  font-size: 1rem;
+  opacity: 0.8;
+}
+
+.summary {
+  background: var(--surface);
+  border-radius: 24px;
+  padding: 1.5rem;
+  box-shadow: var(--shadow);
+}
+
+.summary h2 {
+  margin-top: 0;
+  margin-bottom: 1rem;
+}
+
+.today-counts {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  font-size: 1.05rem;
+}
+
+.today-counts .count-chip {
+  padding: 0.5rem 0.75rem;
+  border-radius: 999px;
+  background: rgba(0, 0, 0, 0.08);
+  color: inherit;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  min-width: 120px;
+  justify-content: center;
+  border: 2px solid transparent;
+  font-weight: 600;
+}
+
+.today-counts .count-chip[data-zone="blue"] {
+  border-color: var(--blue);
+}
+
+.today-counts .count-chip[data-zone="green"] {
+  border-color: var(--green);
+}
+
+.today-counts .count-chip[data-zone="yellow"] {
+  border-color: var(--yellow);
+}
+
+.today-counts .count-chip[data-zone="red"] {
+  border-color: var(--red);
+}
+
+.timeline {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  margin-top: 1rem;
+}
+
+.timeline .timeline-chip {
+  padding: 0.35rem 0.65rem;
+  border-radius: 999px;
+  font-size: 0.9rem;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  border: 2px solid transparent;
+  background: rgba(0, 0, 0, 0.07);
+}
+
+.timeline .timeline-chip[data-zone="blue"] {
+  border-color: var(--blue);
+}
+
+.timeline .timeline-chip[data-zone="green"] {
+  border-color: var(--green);
+}
+
+.timeline .timeline-chip[data-zone="yellow"] {
+  border-color: var(--yellow);
+}
+
+.timeline .timeline-chip[data-zone="red"] {
+  border-color: var(--red);
+}
+
+.teacher-panel {
+  background: var(--surface);
+  border-radius: 24px;
+  padding: 1.5rem;
+  box-shadow: var(--shadow);
+  display: none;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+body.teacher-mode .teacher-panel {
+  display: flex;
+}
+
+.filters {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1.5rem;
+}
+
+.filters fieldset {
+  border: 2px solid rgba(0, 0, 0, 0.08);
+  border-radius: 16px;
+  padding: 1rem;
+  min-width: 220px;
+}
+
+.filters legend {
+  font-weight: 700;
+  padding: 0 0.25rem;
+}
+
+.filters label {
+  display: flex;
+  gap: 0.5rem;
+  align-items: center;
+  margin-top: 0.35rem;
+  font-size: 0.95rem;
+}
+
+.custom-date {
+  display: none;
+  margin-top: 0.5rem;
+  gap: 0.75rem;
+}
+
+.custom-date label {
+  flex-direction: column;
+  align-items: flex-start;
+}
+
+.custom-date input {
+  width: 180px;
+}
+
+.table-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+}
+
+.table-actions button {
+  padding: 0.65rem 1rem;
+  border-radius: 999px;
+  border: none;
+  background: rgba(0, 0, 0, 0.1);
+  font-size: 0.95rem;
+  cursor: pointer;
+}
+
+.table-actions button#clearAll {
+  background: rgba(255, 69, 58, 0.15);
+  color: #d90429;
+  border: 1px solid rgba(255, 69, 58, 0.3);
+}
+
+.table-wrapper {
+  overflow-x: auto;
+}
+
+table {
+  width: 100%;
+  border-collapse: collapse;
+  min-width: 520px;
+}
+
+thead {
+  background: rgba(0, 0, 0, 0.05);
+}
+
+td,
+th {
+  text-align: left;
+  padding: 0.75rem;
+  border-bottom: 1px solid rgba(0, 0, 0, 0.08);
+}
+
+.select-col {
+  width: 48px;
+}
+
+.zone-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  padding: 0.25rem 0.6rem;
+  border-radius: 999px;
+  font-size: 0.9rem;
+  border: 2px solid transparent;
+}
+
+.zone-chip[data-zone="blue"] {
+  border-color: var(--blue);
+}
+
+.zone-chip[data-zone="green"] {
+  border-color: var(--green);
+}
+
+.zone-chip[data-zone="yellow"] {
+  border-color: var(--yellow);
+}
+
+.zone-chip[data-zone="red"] {
+  border-color: var(--red);
+}
+
+.modal {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.45);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 1.5rem;
+  z-index: 1000;
+}
+
+.modal.hidden {
+  display: none;
+}
+
+.modal-content {
+  background: var(--surface);
+  border-radius: 24px;
+  padding: 1.5rem;
+  width: min(420px, 100%);
+  box-shadow: var(--shadow);
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.modal-subtitle {
+  margin: 0;
+  opacity: 0.8;
+}
+
+textarea {
+  width: 100%;
+  border-radius: 16px;
+  border: 1px solid rgba(0, 0, 0, 0.2);
+  padding: 0.75rem;
+  font-size: 1rem;
+  resize: vertical;
+}
+
+.modal-actions {
+  display: flex;
+  gap: 0.75rem;
+  justify-content: flex-end;
+}
+
+.modal-actions .primary {
+  background: var(--accent);
+  color: white;
+  border: none;
+  padding: 0.65rem 1.2rem;
+  border-radius: 999px;
+  font-size: 1rem;
+  cursor: pointer;
+}
+
+.modal-actions .secondary {
+  background: rgba(0, 0, 0, 0.1);
+  border: none;
+  border-radius: 999px;
+  padding: 0.65rem 1.2rem;
+  font-size: 1rem;
+  cursor: pointer;
+}
+
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  border: 0;
+}
+
+@media (max-width: 640px) {
+  body {
+    padding: 1.25rem;
+  }
+
+  .zone-card {
+    min-height: 120px;
+  }
+}


### PR DESCRIPTION
## Summary
- create a single-page Zones of Regulation tracker with large tap targets and optional note capture
- persist entries to localStorage with filtering, CSV export, and data management tools in a teacher view
- style the interface for touch devices, accessibility, and document usage instructions

## Testing
- Manual: opened `index.html`, logged a zone with a note, toggled Teacher View, and verified the history/export controls

------
https://chatgpt.com/codex/tasks/task_e_68d6c2d292b08327b39cc14ac009d3a8